### PR TITLE
Small change in example on site

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@ title: PhpMetrics, static analysis for PHP - by Jean-François Lépine
 
     <div class="highlight">
 <pre>composer global require <span style="color:#0000e6; ">'phpmetrics/phpmetrics'</span>
-phpmetrics --report-html=myreport.html <span style="color:#40015a; ">/path/of/your/sources</span>
+phpmetrics --report-html=/path/to/your/report/in/html <span style="color:#40015a; ">/path/of/your/sources</span>
 </pre>
         </div>
     </div>


### PR DESCRIPTION
Why this change? Because on example references that `--report-html=` will output on file `myreport.html`, but `--report-html=` generate output report on directory with various html files, as below.

```bash
dev@ci08:~/s/c/my-project|features/transfer-between-accounts⚡*?
➤ phpmetrics --report-html=/home/dev/source/other/phpmetrics/my-project/report src/


Executing system analyzes...

LOC
    Lines of code                               27434

...


HTML report generated in "/home/dev/source/other/phpmetrics/my-project/report" directory

Done
```